### PR TITLE
fix #1

### DIFF
--- a/lib/goodbye_chatwork.rb
+++ b/lib/goodbye_chatwork.rb
@@ -37,7 +37,7 @@ module GoodbyeChatwork
       self.wait
       self.info "login as #{@id} ..."
       @token = r.body.match(/var ACCESS_TOKEN *= *'(.+)'/).to_a[1]
-      @myid = r.body.match(/var myid *= *'(.+)'/).to_a[1]
+      @myid = r.body.match(/var MYID *= *'(.+)'/).to_a[1]
       raise 'no token' unless @token
       self.init_load
       self.get_account_info


### PR DESCRIPTION
ChatWork seems to change myid to upper case.
from
```ruby
var myid                       = '*******';
```
to
```ruby
var MYID                       = '*******';
```

I changed the regular expression for new ChatWork document.
Please refer to [#9 NoMethodError: undefined method `[]' for nil:NilClass](https://github.com/swdyh/goodbye_chatwork/issues/9).